### PR TITLE
Custom tagger parameter

### DIFF
--- a/keyphrase_vectorizers/keyphrase_count_vectorizer.py
+++ b/keyphrase_vectorizers/keyphrase_count_vectorizer.py
@@ -76,7 +76,7 @@ class KeyphraseCountVectorizer(_KeyphraseVectorizerMixin, BaseEstimator):
         Type of the matrix returned by fit_transform() or transform().
     """
 
-    def __init__(self, spacy_pipeline: str = 'en_core_web_sm', pos_pattern: str = '<J.*>*<N.*>+',
+    def __init__(self, spacy_pipeline: str = 'en_core_web_sm', pos_pattern: str = '<J.*>*<N.*>+', pos_tagger: Any = None,
                  stop_words: str = 'english', lowercase: bool = True, workers: int = 1, max_df: int = None,
                  min_df: int = None,
                  binary: bool = False, dtype: np.dtype = np.int64):
@@ -124,6 +124,7 @@ class KeyphraseCountVectorizer(_KeyphraseVectorizerMixin, BaseEstimator):
 
         self.spacy_pipeline = spacy_pipeline
         self.pos_pattern = pos_pattern
+        self.pos_tagger = pos_tagger
         self.stop_words = stop_words
         self.lowercase = lowercase
         self.workers = workers

--- a/keyphrase_vectorizers/keyphrase_count_vectorizer.py
+++ b/keyphrase_vectorizers/keyphrase_count_vectorizer.py
@@ -76,7 +76,7 @@ class KeyphraseCountVectorizer(_KeyphraseVectorizerMixin, BaseEstimator):
         Type of the matrix returned by fit_transform() or transform().
     """
 
-    def __init__(self, spacy_pipeline: str = 'en_core_web_sm', pos_pattern: str = '<J.*>*<N.*>+', pos_tagger: Any = None,
+    def __init__(self, spacy_pipeline: str = 'en_core_web_sm', pos_pattern: str = '<J.*>*<N.*>+', pos_tagger: any = None,
                  stop_words: str = 'english', lowercase: bool = True, workers: int = 1, max_df: int = None,
                  min_df: int = None,
                  binary: bool = False, dtype: np.dtype = np.int64):

--- a/keyphrase_vectorizers/keyphrase_vectorizer_mixin.py
+++ b/keyphrase_vectorizers/keyphrase_vectorizer_mixin.py
@@ -276,7 +276,7 @@ class _KeyphraseVectorizerMixin():
 
         # add spaCy POS tags for documents
         spacy_exclude = ['parser', 'ner', 'entity_linker', 'entity_ruler', 'textcat', 'textcat_multilabel',
-                         'lemmatizer', 'morphologizer', 'senter', 'sentencizer', 'transformer']
+                         'lemmatizer', 'morphologizer', 'senter', 'sentencizer', 'tok2vec', 'transformer']
         try:
             nlp = spacy.load(spacy_pipeline,
                              exclude=spacy_exclude)

--- a/keyphrase_vectorizers/keyphrase_vectorizer_mixin.py
+++ b/keyphrase_vectorizers/keyphrase_vectorizer_mixin.py
@@ -179,7 +179,7 @@ class _KeyphraseVectorizerMixin():
                                                                max_text_length=max_text_length)
             return splitted_document
 
-    def _get_pos_keyphrases(self, document_list: List[str], stop_words: str, spacy_pipeline: str, pos_pattern: str,
+    def _get_pos_keyphrases(self, document_list: List[str], stop_words: str, spacy_pipeline: str, pos_pattern: str, pos_tagger: Any = None,
                             lowercase: bool = True, workers: int = 1) -> List[str]:
         """
         Select keyphrases with part-of-speech tagging from a text document.
@@ -298,6 +298,10 @@ class _KeyphraseVectorizerMixin():
 
         # add rule based sentence boundary detection
         nlp.add_pipe('sentencizer')
+
+        if pos_tagger != None:
+          pos_tagger_component = Language.component("pos_tagger", func=pos_tagger)
+          nlp.add_pipe("pos_tagger", name="pos_tagger", first=True)
 
         keyphrases_list = []
         if workers != 1:

--- a/keyphrase_vectorizers/keyphrase_vectorizer_mixin.py
+++ b/keyphrase_vectorizers/keyphrase_vectorizer_mixin.py
@@ -179,7 +179,7 @@ class _KeyphraseVectorizerMixin():
                                                                max_text_length=max_text_length)
             return splitted_document
 
-    def _get_pos_keyphrases(self, document_list: List[str], stop_words: str, spacy_pipeline: str, pos_pattern: str, pos_tagger: Any = None,
+    def _get_pos_keyphrases(self, document_list: List[str], stop_words: str, spacy_pipeline: str, pos_pattern: str, pos_tagger: any = None,
                             lowercase: bool = True, workers: int = 1) -> List[str]:
         """
         Select keyphrases with part-of-speech tagging from a text document.

--- a/keyphrase_vectorizers/keyphrase_vectorizer_mixin.py
+++ b/keyphrase_vectorizers/keyphrase_vectorizer_mixin.py
@@ -309,10 +309,10 @@ class _KeyphraseVectorizerMixin():
         max_doc_length = 1000000
         for document in document_list:
             if len(document) > max_doc_length:
-                docs_list.append(self._split_long_document(text=document, max_text_length=max_doc_length))
+                docs_list.extend(self._split_long_document(text=document, max_text_length=max_doc_length))
             else:
-                docs_list.append([document])
-        document_list = [text for split_text in docs_list for text in split_text]
+                docs_list.append(document)
+        document_list = docs_list
         del docs_list
 
         # increase max length of documents that spaCy can parse


### PR DESCRIPTION
In this pull request, I added a 'pos_tagger' parameter that can be passed to KeyphraseCountVectorizer.
If passed, it adds the custom tagger to the pipeline.

pos_tagger is a function that will be added as a custom pipeline component, as shown in the [SpaCy documentation](https://spacy.io/usage/processing-pipelines#custom-components).

I also changed the way the list was made when document is too long and removed tok2vec from pipeline as I think it is not necessary in this case.

In relation to issue #2 
